### PR TITLE
Changed print() to minetest.log() to avoid annoying players in 0.4.15

### DIFF
--- a/income.lua
+++ b/income.lua
@@ -11,7 +11,7 @@ minetest.register_globalstep(function(dtime)
                     players_income[name] = 0
                 end
                 players_income[name] = 1
-                print("[Currency] basic income for "..name.."")
+                minetest.log("info", "[Currency] basic income for "..name.."")
         end
     end
 end)
@@ -27,7 +27,7 @@ earn_income = function(player)
         local inv = player:get_inventory()
         inv:add_item("main", {name="currency:minegeld_5", count=count})
         players_income[name] = 0
-        print("[Currency] added basic income for "..name.." to inventory")
+        minetest.log("info", "[Currency] added basic income for "..name.." to inventory")
     end
 end
 

--- a/init.lua
+++ b/init.lua
@@ -1,20 +1,20 @@
-print(" Currency mod loading... ")
+minetest.log("info", " Currency mod loading... ")
 local modpath = minetest.get_modpath("currency")
 
 dofile(modpath.."/craftitems.lua")
-print("[Currency] Craft_items Loaded!")
+minetest.log("info", "[Currency] Craft_items Loaded!")
 dofile(modpath.."/shop.lua")
-print("[Currency] Shop Loaded!")
+minetest.log("info", "[Currency] Shop Loaded!")
 dofile(modpath.."/barter.lua")
-print("[Currency]  Barter Loaded!")
+minetest.log("info", "[Currency]  Barter Loaded!")
 dofile(modpath.."/safe.lua")
-print("[Currency] Safe Loaded!")
+minetest.log("info", "[Currency] Safe Loaded!")
 dofile(modpath.."/crafting.lua")
-print("[Currency] Crafting Loaded!")
+minetest.log("info", "[Currency] Crafting Loaded!")
 
 if minetest.setting_getbool("creative_mode") then
-	print("[Currency] Creative mode in use, skipping basic income.")
+	minetest.log("info", "[Currency] Creative mode in use, skipping basic income.")
 else
 	dofile(modpath.."/income.lua")
-	print("[Currency] Income Loaded!")
+	minetest.log("info", "[Currency] Income Loaded!")
 end


### PR DESCRIPTION
In 0.4.15, print() behaves like minetest.chat_send_all(), so players are spammed with info. I changed this into informational log entries.