### PR TITLE
Replace deprecated 'setting_getbool' with 'settings:get_bool'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -16,7 +16,7 @@ minetest.log("info", "[Currency] "..S("Safe Loaded!"))
 dofile(modpath.."/crafting.lua")
 minetest.log("info", "[Currency] "..S("Crafting Loaded!"))
 
-if minetest.setting_getbool("creative_mode") then
+if minetest.settings:get_bool("creative_mode") then
 	minetest.log("info", "[Currency] "..S("Creative mode in use, skipping basic income."))
 else
 	dofile(modpath.."/income.lua")


### PR DESCRIPTION
May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267