### PR TITLE
Test for global 'pipeworks' before calling

### DIFF
--- a/shop.lua
+++ b/shop.lua
@@ -33,6 +33,8 @@ default.shop.formspec = {
 	end,
 }
 
+local have_pipeworks = minetest.global_exists("pipeworks")
+
 default.shop.check_privilege = function(listname,playername,meta)
 	--[[if listname == "pl1" then
 		if playername ~= meta:get_string("pl1") then
@@ -104,9 +106,9 @@ minetest.register_node("currency:shop", {
 		inv:set_size("stock", 3*2)
 		inv:set_size("owner_wants", 3*2)
 		inv:set_size("owner_gives", 3*2)
-		if minetest.get_modpath("pipeworks") then pipeworks.after_place(pos) end
+		if have_pipeworks then pipeworks.after_place(pos) end
 	end,
-	after_dig_node = (pipeworks and pipeworks.after_dig),
+	after_dig_node = (have_pipeworks and pipeworks and pipeworks.after_dig),
 	tube = {
 		insert_object = function(pos, node, stack, direction)
 			local meta = minetest.get_meta(pos)


### PR DESCRIPTION
I was getting the following warning if `pipeworks` was not installed:

> 2017-05-14 16:25:46: WARNING[Main]: Undeclared global variable "pipeworks" accessed at ...hare/minetest/games/antum-testing/mods/currency/shop.lua:109

I'm not 100% sure that I fixed it correctly, but I set a local variable with the value of `minetest.global_exists("pipeworks")` to replace & be checked before calls to `pipeworks` global.